### PR TITLE
Fix issues 13 and 15

### DIFF
--- a/modules/browser/src/main/kotlin/org/gjt/jclasslib/browser/MacEventHandler.kt
+++ b/modules/browser/src/main/kotlin/org/gjt/jclasslib/browser/MacEventHandler.kt
@@ -8,11 +8,29 @@
 package org.gjt.jclasslib.browser
 
 import com.apple.eawt.Application
+import java.awt.Desktop
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 
 object MacEventHandler {
     fun init() {
-        Application.getApplication().apply {
-            setAboutHandler { getActiveBrowserFrame()?.aboutAction?.invoke()}
+        try {
+            Application.getApplication().apply {
+                setAboutHandler { getActiveBrowserFrame()?.aboutAction?.invoke()}
+            }
+        } catch (e: NoClassDefFoundError) {
+            val desktop = Desktop.getDesktop()
+            val about = Class.forName("java.awt.desktop.AboutHandler")
+            val proxy : Any = Proxy.newProxyInstance(about.getClassLoader(), arrayOf(about), Java9MacAboutHandler)
+            desktop::class.java.getMethod("setAboutHandler", *arrayOf(about))?.invoke(desktop, proxy)
         }
+    }
+}
+
+
+object Java9MacAboutHandler : InvocationHandler {
+    override fun invoke(proxy: Any?, method: Method?, args: Array<Any?>?) {
+        getActiveBrowserFrame()?.aboutAction?.invoke()
     }
 }


### PR DESCRIPTION
The com.apple.eawt package is not available in Java 9.  This update calls the new way (http://openjdk.java.net/jeps/272) via reflection when the initial error is encountered.