### PR TITLE
Improve macOS on Java 9 logic

### DIFF
--- a/modules/browser/src/main/kotlin/org/gjt/jclasslib/browser/MacEventHandler.kt
+++ b/modules/browser/src/main/kotlin/org/gjt/jclasslib/browser/MacEventHandler.kt
@@ -19,7 +19,7 @@ object MacEventHandler {
             Application.getApplication().apply {
                 setAboutHandler { getActiveBrowserFrame()?.aboutAction?.invoke()}
             }
-        } catch (e: NoClassDefFoundError) {
+        } catch (e: LinkageError) {
             val desktop = Desktop.getDesktop()
             val aboutHandlerClass = Class.forName("java.awt.desktop.AboutHandler")
             val proxy = Proxy.newProxyInstance(aboutHandlerClass.classLoader, arrayOf(aboutHandlerClass), Java9MacAboutHandler)


### PR DESCRIPTION
This is a wider catch, as java may be able to see the Application class but not the method depending on how the browser is run.